### PR TITLE
Refactor for Multiple Auth Schemes

### DIFF
--- a/get_data.py
+++ b/get_data.py
@@ -174,11 +174,13 @@ def main():
 
     start = args.start
     end = args.end
+    offset = cfg["time_offset_seconds"]
 
     if not start:
-        # use the most recent record as the start date
+        # use the most recent record as the start date (minus the offset)
         start = most_recent(pgrest, cfg["provider_id"])
         start = to_unix(start)
+        start = start - offset
 
     if not end:
         # use current time as the end date

--- a/get_data.py
+++ b/get_data.py
@@ -192,10 +192,7 @@ def main():
 
     auth_type = cfg.get("auth_type")
 
-    if auth_type.lower() == "httpbasicauth":
-        print("this is not needed")
-
-    elif not cfg.get("token") and auth_type.lower() != "httpbasicauth":
+    if not cfg.get("token") and auth_type.lower() != "httpbasicauth":
         token_res = get_token(cfg["auth_url"], cfg["auth_data"])
         cfg["token"] = token_res[cfg["auth_token_res_key"]]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/cityofaustin/mds-provider-client.git@master#egg=mds_provider_client0.1.3
+git+https://github.com/cityofaustin/mds-provider-client.git@master#egg=mds_provider_client0.1.4
 arrow
 pypgrest
 pytz


### PR DESCRIPTION
A new provider uses jwt. To address this different auth flow we refactored the config as well as the auth methods and pre-client setup. Also adds support for specifying a start time offset, which subtracts an arbitrary amount of time from the start time of the request to capture recent records that may have been updated since the last trip record was captured.